### PR TITLE
Switch projectile bindings to helm-projectile

### DIFF
--- a/conf/load-packages.el
+++ b/conf/load-packages.el
@@ -78,7 +78,10 @@
   :ensure t)
 
 (use-package helm-projectile
-  :bind ("C-c h" . helm-projectile)
+  :bind (("C-c h" . helm-projectile)
+         ("C-c p f" . helm-projectile-find-file)
+         ("C-c p p" . helm-projectile-switch-project)
+         ("C-c p b" . helm-projectile-switch-to-buffer))
   :ensure t)
 
 (use-package helm-swoop

--- a/init.el
+++ b/init.el
@@ -54,6 +54,8 @@
 (add-to-list 'load-path "~/.emacs.d/conf/")
 (add-to-list 'load-path "~/.emacs.d/source/")
 
+; TODO the following should be integrated with use-package
+
 (require 'load-packages)
 (require 'pit-elisp-mode)
 (require 'custom-go-mode)


### PR DESCRIPTION
Add bindings for helm-projectile.

```
:bind (("C-c h" . helm-projectile)
     ("C-c p f" . helm-projectile-find-file)
     ("C-c p p" . helm-projectile-switch-project)
     ("C-c p b" . helm-projectile-switch-to-buffer))
```
